### PR TITLE
Updated CSS for Contrast & Inverted controls

### DIFF
--- a/assets/scss/best-motherfucking-website/best-motherfucking-website.scss
+++ b/assets/scss/best-motherfucking-website/best-motherfucking-website.scss
@@ -306,6 +306,17 @@ div#invmode{
   @extend .noselect;
 }
 
+@media screen and (max-width:1080px) {
+
+  div#contrast {
+    position: absolute;
+  }
+
+  div#invmode {
+    position: absolute;
+  }
+}
+
 span.sb{
   cursor: not-allowed;
   color: $shittyBlue;


### PR DESCRIPTION
Made them revert to thebestmotherfuckingsite behavior (position: absolute, prepended at top-right corner of the page) if the space for them is unavailable (max-width< 1080). Thus, on smaller screens, they won't clip through text and would be located at the top of the page instead.